### PR TITLE
added table of contents and fixed license

### DIFF
--- a/Develop/index.js
+++ b/Develop/index.js
@@ -1,33 +1,9 @@
-
-// WHEN I am prompted for information about my application repository
-// THEN a high-quality, professional README.md is generated with the title of my project and sections entitled Description, Table of Contents, Installation, Usage, License, Contributing, Tests, and Questions
-
-// WHEN I enter my project title
-// THEN this is displayed as the title of the README
-
-// WHEN I enter a description, installation instructions, usage information, contribution guidelines, and test instructions
-// THEN this information is added to the sections of the README entitled Description, Installation, Usage, Contributing, and Tests
-
-// WHEN I choose a license for my application from a list of options
-// THEN a badge for that license is added near the top of the README and a notice is added to the section of the README entitled License that explains which license the application is covered under
-
-// WHEN I enter my GitHub username
-// THEN this is added to the section of the README entitled Questions, with a link to my GitHub profile
-
-// WHEN I enter my email address
-// THEN this is added to the section of the README entitled Questions, with instructions on how to reach me with additional questions
-
-// WHEN I click on the links in the Table of Contents
-// THEN I am taken to the corresponding section of the README
-
-
-// TODO: Include packages needed for this application
 const inquirer = require('inquirer');
 const fs = require('fs');
 const { default: Choices } = require("inquirer/lib/objects/choices");
 
 
-// TODO: Create an array of questions for user input
+// Runs a series of inquirer prompts
 inquirer
 .prompt([
     {
@@ -117,13 +93,6 @@ inquirer
     ])
     .then((data) => {
         const genMarkdown = require('./utils/generateMarkdown');
+        // Generates the file with the string generated in generateMarkdown.js
         fs.writeFile('README.md', genMarkdown.generateMarkdown(data), (err) => err && console.error(err));
     });
-    
-    // TODO: Create a function to write README file
-    
-    // TODO: Create a function to initialize app
-    
-    // Function call to initialize app
-    // init();
-    

--- a/Develop/utils/generateMarkdown.js
+++ b/Develop/utils/generateMarkdown.js
@@ -1,13 +1,11 @@
-
-
 function generateMarkdown(data) {
   // Returns a license badge based on which license is passed in
   function renderLicenseBadge() {
-    if(this.license === 'MIT') {
+    if(data.license == 'MIT') {
       return '[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)'
-    } else if(this.license === 'Apache') {
+    } else if(data.license == 'Apache') {
       return '[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)'
-    } else if(this.license === 'GNU') {
+    } else if(data.license == 'GNU') {
       return '[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)'
     } else {
       // If there is no license, returns an empty string
@@ -15,15 +13,13 @@ function generateMarkdown(data) {
     }
   }
   
-  let licenseBadge = renderLicenseBadge();
-  
   // Returns the license link
   function renderLicenseLink() {
-    if(this.license === 'MIT') {
+    if(data.license == 'MIT') {
       return 'https://opensource.org/licenses/MIT'
-    } else if(this.license === 'Apache') {
+    } else if(data.license == 'Apache') {
       return 'https://opensource.org/licenses/Apache-2.0'
-    } else if(this.license === 'GNU') {
+    } else if(data.license == 'GNU') {
       return 'https://www.gnu.org/licenses/gpl-3.0'
     } else {
       // If there is no license, returns an empty string
@@ -31,13 +27,23 @@ function generateMarkdown(data) {
     }
   }
   
-  let licenseLink = renderLicenseLink();
-  
   // Generates markdown for README
   return `# ${data.title}
 ## Description
 ${data.description} ${data.motivation} ${data.problem} ${data.learned}
 ## Table of contents
+[Installation](#installation)
+
+[Usage](#usage)
+
+[Credits](#credits)
+
+[Tests](#tests)
+
+[License](#license)
+
+[Questions](#questions)
+
 ## Installation
 ${data.installation}
 ## Usage
@@ -47,8 +53,9 @@ ${data.collaborators} ${data.thirdParty} ${data.tutorials}
 ## Tests
 ${data.tests}
 ## License
-${licenseBadge}
-${licenseLink}
+${renderLicenseBadge()}
+
+${renderLicenseLink()}
 ## Questions
 If you have any questions or feedback, you can reach out to me via Github: ${data.username} or email: ${data.email}.
 `;


### PR DESCRIPTION
Added links to the markdown string that snap to respective headings in the readme when clicked. Also fixed the issue of the license functions always returning empty strings by calling the functions directly in the markdown string.